### PR TITLE
Add PHP 7.3 and 7.4 to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 language: php
 dist: trusty
 cache:
@@ -12,7 +12,7 @@ php:
   - 7.1
   - 7.2
   - nightly
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,17 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - nightly
 jobs:
   include:
     - php: 5.3
       dist: precise
+    - php: nightly
+      env: COMPOSER_ADDITIONAL_FLAGS=--ignore-platform-reqs
   fast_finish: true
   allow_failures:
     - php: nightly
 install:
   - test -f composer.lock && rm composer.lock || true
-  - ./composer update --ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress
+  - ./composer update --ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress $COMPOSER_ADDITIONAL_FLAGS
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
   - nightly
 jobs:
   include:


### PR DESCRIPTION
Also, there are few warnings in Travis about the `.travis.yml` that can be easily fixed