### PR TITLE
Introduce ComposerWrapperOptions to fetch options from both ENV and composer.json

### DIFF
--- a/composer
+++ b/composer
@@ -24,6 +24,17 @@ if (!class_exists('ComposerWrapper')) {
          * @var string
          */
         private $composerDir = __DIR__;
+        /**
+         * @var string
+         */
+        private $wrapperDir = __DIR__;
+
+        public function __construct($wrapperDir = null)
+        {
+            if (null !== $wrapperDir) {
+                $this->wrapperDir = $wrapperDir;
+            }
+        }
 
         public function loadReal()
         {
@@ -48,7 +59,7 @@ if (!class_exists('ComposerWrapper')) {
 
         private function loadComposerJson()
         {
-            $file = __DIR__ . '/composer.json';
+            $file = $this->wrapperDir . '/composer.json';
             // It is the same logic of reading composer.json as is in the Composer
             if (!is_file($file) || !is_readable($file) || !is_array($composer = json_decode(file_get_contents($file),                                                                                        true))) {
                 return;
@@ -60,10 +71,13 @@ if (!class_exists('ComposerWrapper')) {
 
             $wrapper = $composer['config']['wrapper'];
             if (!empty($wrapper['update-freq'])) {
-                $this->updateFreq = $wrapper['update-freq'];
+                $this->setUpdateFreq($wrapper['update-freq']);
             }
             if (!empty($wrapper['major-version'])) {
-                $this->updateFreq = $wrapper['major-version'];
+                $this->setForceMajorVersion($wrapper['major-version']);
+            }
+            if (!empty($wrapper['composer-dir'])) {
+                $this->setComposerDir($wrapper['composer-dir']);
             }
         }
 

--- a/composer
+++ b/composer
@@ -122,12 +122,18 @@ if (!class_exists('ComposerWrapper')) {
          */
         public function setUpdateFreq($updateFreq)
         {
-            // DateTime $modifier validation. Taken from https://stackoverflow.com/a/34899724/2165434
-            $d = new DateTime();
-            $modified = @$d->modify($updateFreq);
+            $now = new DateTime('now', new DateTimeZone('UTC'));
+            $modified = clone $now;
 
-            if ($modified === false) {
+            //hack: DateTime $modifier argument validation. Taken from https://stackoverflow.com/a/34899724/2165434
+            $success = @$modified->modify($updateFreq);
+            if ($success === false) {
                 throw new \Exception(sprintf('Wrong update frequency is requested: %s; should be valid DateTime modifier (follow %s for the help)', $updateFreq,'https://www.php.net/manual/en/datetime.modify.php'));
+            }
+            //endhack
+
+            if ($modified < $now) {
+                throw new \Exception(sprintf('Wrong update frequency is requested: %s; composer update frequency must not be negative', $updateFreq));
             }
 
             $this->updateFreq = (string) $updateFreq;
@@ -354,12 +360,6 @@ if (!class_exists('ComposerWrapper')) {
             $composerUpdateFrequency = $this->params->getUpdateFreq();
 
             $now = new \DateTime('now', new DateTimeZone('UTC'));
-            $nowClone = clone $now;
-            $nowPlusFrequency = $nowClone->modify($composerUpdateFrequency);
-
-            if ($nowPlusFrequency < $now) {
-                $this->showError('Composer update frequency must not be negative');
-            }
 
             $mtimeTimestamp = \filemtime($filename);
             $mtimePlusFrequency = \DateTime::createFromFormat(

--- a/composer
+++ b/composer
@@ -11,6 +11,68 @@
  * @version 1.1.0
  */
 if (!class_exists('ComposerWrapper')) {
+    class ComposerWrapperParams {
+        /**
+         * @var int|false
+         */
+        private $forceMajorVersion = false;
+        private $updateFreq = '7 days';
+
+        public function loadReal()
+        {
+            $this->loadComposerJson();
+            // env variables have the highest priority
+            $this->loadEnv();
+        }
+
+        private function loadEnv()
+        {
+            $this->updateFreq = \getenv(
+                'COMPOSER_UPDATE_FREQ'
+            );
+            $this->forceMajorVersion = \filter_var(
+                \getenv('COMPOSER_FORCE_MAJOR_VERSION'),
+                FILTER_VALIDATE_INT
+            );
+        }
+
+        private function loadComposerJson()
+        {
+            //stub
+        }
+
+        /**
+         * @return bool
+         */
+        public function getForceMajorVersion()
+        {
+            return $this->forceMajorVersion;
+        }
+
+        /**
+         * @param false|int $forceMajorVersion
+         */
+        public function setForceMajorVersion($forceMajorVersion)
+        {
+            $this->forceMajorVersion = $forceMajorVersion;
+        }
+
+        /**
+         * @return string
+         */
+        public function getUpdateFreq()
+        {
+            return $this->updateFreq;
+        }
+
+        /**
+         * @param string $updateFreq
+         */
+        public function setUpdateFreq($updateFreq)
+        {
+            $this->updateFreq = $updateFreq;
+        }
+    }
     class ComposerWrapper
     {
         const COMPOSER_HASHBANG = "#!/usr/bin/env php\n";
@@ -30,7 +92,15 @@ if (!class_exists('ComposerWrapper')) {
         const MSG_SELF_UPDATE_FAILED = 'composer self-update failed; proceeding with existing';
         const EXIT_CODE_COMPOSER_EXCEPTION = 6;
 
-        const ENV_FORCE_VERSION = 'COMPOSER_FORCE_MAJOR_VERSION';
+        /**
+         * @var ComposerWrapperParams
+         */
+        protected $params;
+
+        public function __construct()
+        {
+            $this->params = new ComposerWrapperParams();
+        }
 
         protected function file_get_contents()
         {
@@ -143,13 +213,6 @@ if (!class_exists('ComposerWrapper')) {
             unset($exitCode);
         }
 
-        protected function getIntFromEnv($envVarName)
-        {
-            return \filter_var(
-                \getenv($envVarName),
-                FILTER_VALIDATE_INT
-            );
-        }
 
         protected function verifyChecksum($installerPathName)
         {
@@ -205,11 +268,8 @@ if (!class_exists('ComposerWrapper')) {
 
         protected function isUpToDate($filename)
         {
-            $composerUpdateFrequency = '7 days';
-            $composerUpdateFrequencyEnv = \getenv(
-                'COMPOSER_UPDATE_FREQ'
-            );
-            if (\strlen($composerUpdateFrequencyEnv) > 1) {
+            $composerUpdateFrequencyEnv = $this->params->getUpdateFreq();
+            if (\strlen($composerUpdateFrequencyEnv) > 1) { // why?
                 $composerUpdateFrequency = $composerUpdateFrequencyEnv;
             }
 
@@ -253,7 +313,7 @@ if (!class_exists('ComposerWrapper')) {
 
         private function getSelfUpdateFlags($filename)
         {
-            $forceVersionRequested = $this->getIntFromEnv(self::ENV_FORCE_VERSION);
+            $forceVersionRequested = $this->params->getForceMajorVersion();
             $flags = '';
             if (false === $forceVersionRequested) {
                 return $flags;
@@ -263,7 +323,7 @@ if (!class_exists('ComposerWrapper')) {
                 throw new Exception(
                     sprintf(
                         'Wrong major version is requested: "%s"; only 1 and 2 are supported',
-                        \getenv(self::ENV_FORCE_VERSION)
+                        $forceVersionRequested
                     )
                 );
             }
@@ -354,6 +414,7 @@ if (!class_exists('ComposerWrapper')) {
          */
         public function run()
         {
+            $this->params->loadReal();
             $composerPathName = "{$this->getComposerDir()}/composer.phar";
 
             $this->ensureInstalled($composerPathName);

--- a/composer
+++ b/composer
@@ -16,7 +16,14 @@ if (!class_exists('ComposerWrapper')) {
          * @var int|false
          */
         private $forceMajorVersion = false;
+        /**
+         * @var string
+         */
         private $updateFreq = '7 days';
+        /**
+         * @var string
+         */
+        private $composerDir = __DIR__;
 
         public function loadReal()
         {
@@ -25,20 +32,39 @@ if (!class_exists('ComposerWrapper')) {
             $this->loadEnv();
         }
 
+
         private function loadEnv()
         {
-            $this->updateFreq = \getenv(
-                'COMPOSER_UPDATE_FREQ'
-            );
-            $this->forceMajorVersion = \filter_var(
-                \getenv('COMPOSER_FORCE_MAJOR_VERSION'),
-                FILTER_VALIDATE_INT
-            );
+            if ( false !== $value = \getenv('COMPOSER_UPDATE_FREQ')) {
+                $this->setUpdateFreq($value);
+            }
+            if ( false !== $value = \getenv('COMPOSER_FORCE_MAJOR_VERSION')) {
+                $this->setForceMajorVersion($value);
+            }
+            if ( false !== $value = \getenv('COMPOSER_DIR')) {
+                $this->setComposerDir($value);
+            }
         }
 
         private function loadComposerJson()
         {
-            //stub
+            $file = __DIR__ . '/composer.json';
+            // It is the same logic of reading composer.json as is in the Composer
+            if (!is_file($file) || !is_readable($file) || !is_array($composer = json_decode(file_get_contents($file),                                                                                        true))) {
+                return;
+            }
+
+            if (empty($composer['config']['wrapper'])) {
+                return;
+            }
+
+            $wrapper = $composer['config']['wrapper'];
+            if (!empty($wrapper['update-freq'])) {
+                $this->updateFreq = $wrapper['update-freq'];
+            }
+            if (!empty($wrapper['major-version'])) {
+                $this->updateFreq = $wrapper['major-version'];
+            }
         }
 
         /**
@@ -50,11 +76,20 @@ if (!class_exists('ComposerWrapper')) {
         }
 
         /**
-         * @param false|int $forceMajorVersion
+         * @param false|int $version
          */
-        public function setForceMajorVersion($forceMajorVersion)
+        public function setForceMajorVersion($version)
         {
-            $this->forceMajorVersion = $forceMajorVersion;
+            $allowed = array("1", 1, "2", 2);
+            if (false === in_array($version, $allowed, true)) {
+                throw new Exception(
+                    sprintf(
+                        'Wrong major version is requested: "%s"; only 1 and 2 are supported in string or integer format',
+                        $version
+                    )
+                );
+            }
+            $this->forceMajorVersion = (int) $version;
         }
 
         /**
@@ -62,6 +97,7 @@ if (!class_exists('ComposerWrapper')) {
          */
         public function getUpdateFreq()
         {
+
             return $this->updateFreq;
         }
 
@@ -70,8 +106,39 @@ if (!class_exists('ComposerWrapper')) {
          */
         public function setUpdateFreq($updateFreq)
         {
-            $this->updateFreq = $updateFreq;
+            // DateTime $modifier validation. Taken from https://stackoverflow.com/a/34899724/2165434
+            $d = new DateTime();
+            $isValid = @$d->modify($updateFreq);
+
+            if ($isValid === false) {
+                throw new \Exception(sprintf('Wrong update frequency is requested: %s; should be valid DateTime modifier (follow %s for the help)', $updateFreq,'https://www.php.net/manual/en/datetime.modify.php'));
+            }
+
+            $this->updateFreq = (string) $updateFreq;
         }
+
+        /**
+         * @return string
+         */
+        public function getComposerDir()
+        {
+            return $this->composerDir;
+        }
+
+        /**
+         * @param string $composerDir
+         */
+        public function setComposerDir($composerDir)
+        {
+            if (!is_dir($composerDir) || !is_writable($composerDir)) {
+                throw new \Exception(sprintf(
+                        "Wrong composer dir is requested: %s; argument is not a dir or is not writable dir",
+                        $composerDir));
+            }
+
+            $this->composerDir = (string) $composerDir;
+        }
+
     }
     class ComposerWrapper
     {
@@ -268,10 +335,7 @@ if (!class_exists('ComposerWrapper')) {
 
         protected function isUpToDate($filename)
         {
-            $composerUpdateFrequencyEnv = $this->params->getUpdateFreq();
-            if (\strlen($composerUpdateFrequencyEnv) > 1) { // why?
-                $composerUpdateFrequency = $composerUpdateFrequencyEnv;
-            }
+            $composerUpdateFrequency = $this->params->getUpdateFreq();
 
             $now = new \DateTime('now', new DateTimeZone('UTC'));
             $nowClone = clone $now;
@@ -317,15 +381,6 @@ if (!class_exists('ComposerWrapper')) {
             $flags = '';
             if (false === $forceVersionRequested) {
                 return $flags;
-            }
-
-            if ($forceVersionRequested && 1 !== $forceVersionRequested && 2 !== $forceVersionRequested) {
-                throw new Exception(
-                    sprintf(
-                        'Wrong major version is requested: "%s"; only 1 and 2 are supported',
-                        $forceVersionRequested
-                    )
-                );
             }
 
             if ($this->supportsForceVersionFlag(
@@ -390,32 +445,12 @@ if (!class_exists('ComposerWrapper')) {
         }
 
         /**
-         * @return string
-         * @throws Exception
-         */
-        private function getComposerDir()
-        {
-            $defaultComposerDir = __DIR__;
-            $composerDirEnv = \getenv('COMPOSER_DIR');
-
-            if (\strlen($composerDirEnv) > 0) {
-                if (!is_dir($composerDirEnv)) {
-                    throw new \Exception("$composerDirEnv is not a dir");
-                }
-
-                return $composerDirEnv;
-            }
-
-            return $defaultComposerDir;
-        }
-
-        /**
          * @throws Exception
          */
         public function run()
         {
             $this->params->loadReal();
-            $composerPathName = "{$this->getComposerDir()}/composer.phar";
+            $composerPathName = "{$this->params->getComposerDir()}/composer.phar";
 
             $this->ensureInstalled($composerPathName);
             $this->ensureExecutable($composerPathName);

--- a/composer
+++ b/composer
@@ -61,7 +61,9 @@ if (!class_exists('ComposerWrapper')) {
         {
             $file = $this->wrapperDir . '/composer.json';
             // It is the same logic of reading composer.json as is in the Composer
-            if (!is_file($file) || !is_readable($file) || !is_array($composer = json_decode(file_get_contents($file),                                                                                        true))) {
+            if (!is_file($file)
+                || !is_readable($file)
+                || !is_array($composer = json_decode(file_get_contents($file),true))) {
                 return;
             }
 

--- a/composer
+++ b/composer
@@ -8,7 +8,7 @@
  * If it breaks, check out newer version or report an issue at
  * https://github.com/kamazee/composer-wrapper
  *
- * @version 1.1.0
+ * @version 1.2.0
  */
 if (!class_exists('ComposerWrapper')) {
     class ComposerWrapperParams {
@@ -68,15 +68,15 @@ if (!class_exists('ComposerWrapper')) {
             if (empty($composer['config']['wrapper'])) {
                 return;
             }
-
             $wrapper = $composer['config']['wrapper'];
-            if (!empty($wrapper['update-freq'])) {
+
+            if (array_key_exists('update-freq', $wrapper)) {
                 $this->setUpdateFreq($wrapper['update-freq']);
             }
-            if (!empty($wrapper['major-version'])) {
+            if (array_key_exists('major-version', $wrapper)) {
                 $this->setForceMajorVersion($wrapper['major-version']);
             }
-            if (!empty($wrapper['composer-dir'])) {
+            if (array_key_exists('composer-dir', $wrapper)) {
                 $this->setComposerDir($wrapper['composer-dir']);
             }
         }
@@ -122,9 +122,9 @@ if (!class_exists('ComposerWrapper')) {
         {
             // DateTime $modifier validation. Taken from https://stackoverflow.com/a/34899724/2165434
             $d = new DateTime();
-            $isValid = @$d->modify($updateFreq);
+            $modified = @$d->modify($updateFreq);
 
-            if ($isValid === false) {
+            if ($modified === false) {
                 throw new \Exception(sprintf('Wrong update frequency is requested: %s; should be valid DateTime modifier (follow %s for the help)', $updateFreq,'https://www.php.net/manual/en/datetime.modify.php'));
             }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-    processIsolation="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
 >
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
-    processIsolation="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    processIsolation="false"
 >
 
     <testsuites>

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -46,8 +46,14 @@ class BaseTestCase extends TestCase
         $property->setValue($object, $arg);
     }
 
-    protected static function isolatedEnv(array $env, callable $callback)
+    protected static function isolatedEnv(array $env, $callback)
     {
+        // php 5.3 doesn't support callable pseudo type hint :(
+        if (!is_callable($callback)) {
+            throw new \Exception(
+                sprintf("%s should be callable; got %s", '$callback', gettype($callback))
+            );
+        }
         foreach ($env as $name => $value) {
             putenv($name . '=' . self::convertToStringIfFloat($value));
         }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -45,4 +45,30 @@ class BaseTestCase extends TestCase
 
         $property->setValue($object, $arg);
     }
+
+    protected function expectExceptionMessageCompat($class, $message)
+    {
+        if (
+            method_exists($this, 'expectExceptionMessage') &&
+            method_exists($this, 'expectException')
+        ) {
+            $this->expectException($class);
+            $this->expectExceptionMessage($message);
+        } elseif (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($class, $message);
+        }
+    }
+
+    protected function expectExceptionMessageRegExpCompat($class, $regExp)
+    {
+        if (
+            method_exists($this, 'expectExceptionMessage') &&
+            method_exists($this, 'expectException')
+        ) {
+            $this->expectException($class);
+            $this->expectExceptionMessageRegExp($regExp);
+        } elseif (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedExceptionRegExp($class, $regExp);
+        }
+    }
 }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -13,9 +13,9 @@ class BaseTestCase extends TestCase
     }
 
 
-    private static function fullWrapperPath()
+    protected static function fullWrapperPath()
     {
-        return __DIR__ . '/' . self::WRAPPER;
+        return realpath(__DIR__ . '/' . self::WRAPPER);
     }
 
     protected function expectOutputWithShebang($output = null)

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -46,6 +46,35 @@ class BaseTestCase extends TestCase
         $property->setValue($object, $arg);
     }
 
+    protected static function isolatedEnv(array $env, callable $callback)
+    {
+        foreach ($env as $name => $value) {
+            putenv($name . '=' . self::convertToStringIfFloat($value));
+        }
+        try {
+            $callback();
+        } catch (Exception $e) {
+
+        }
+        foreach ($env as $name => $value) {
+            putenv($name);
+        }
+
+        if (isset($e)) {
+            throw $e;
+        }
+    }
+
+    protected static function convertToStringIfFloat($value)
+    {
+        if (is_float($value)) {
+            //float value 1.0 should be passed as "1.0" string but not "1"
+            $value = number_format($value, 1, '.', '');
+        }
+
+        return $value;
+    }
+
     protected function expectExceptionMessageCompat($class, $message)
     {
         if (

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class BaseTestCase extends TestCase
+{
+    const WRAPPER = '../composer';
+
+    public function setUp()
+    {
+        $this->expectOutputWithShebang();
+        require self::fullWrapperPath();
+    }
+
+
+    private static function fullWrapperPath()
+    {
+        return __DIR__ . '/' . self::WRAPPER;
+    }
+
+    protected function expectOutputWithShebang($output = null)
+    {
+        $shebang = $this->getExpectedShebang();
+        $this->expectOutputString($shebang . $output);
+    }
+
+    private function getExpectedShebang()
+    {
+        $wrapperFileLines = file(self::fullWrapperPath());
+        return $wrapperFileLines[0];
+    }
+
+    protected static function callNonPublic($object, $method, $args)
+    {
+        $method = new ReflectionMethod($object, $method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
+    }
+
+    protected static function setNonPublic($object, $property, $arg)
+    {
+        $property = new ReflectionProperty($object, $property);
+        $property->setAccessible(true);
+
+        $property->setValue($object, $arg);
+    }
+}

--- a/tests/ComposerWrapperParamsTest.php
+++ b/tests/ComposerWrapperParamsTest.php
@@ -4,8 +4,6 @@ require_once __DIR__ . '/BaseTestCase.php';
 
 use BaseTestCase as TestCase;
 use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
-use org\bovigo\vfs\vfsStreamWrapper;
 
 class ComposerWrapperParamsTest extends TestCase
 {

--- a/tests/ComposerWrapperParamsTest.php
+++ b/tests/ComposerWrapperParamsTest.php
@@ -322,7 +322,7 @@ class ComposerWrapperParamsTest extends TestCase
         $json = vfsStream::url('root/composer.json');
 
         $options = 0;
-        if (null !== constant('JSON_PRESERVE_ZERO_FRACTION')) {
+        if (defined('JSON_PRESERVE_ZERO_FRACTION')) {
             $options = JSON_PRESERVE_ZERO_FRACTION;
         }
         $configWithNonDefaultValues = json_encode(array("config" => array("wrapper" => $wrapperConfig)), $options);

--- a/tests/ComposerWrapperParamsTest.php
+++ b/tests/ComposerWrapperParamsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once __DIR__ . '/BaseTestCase.php';
+
+use BaseTestCase as TestCase;
+
+class ComposerWrapperParamsTest extends TestCase
+{
+    const COMPOSER_WRAPPER_PARAMS = 'ComposerWrapperParams';
+
+    public function setUp()
+    {
+        parent::setUp();
+        self::assertTrue(class_exists(self::COMPOSER_WRAPPER_PARAMS));
+    }
+
+    /**
+     * @test
+     */
+    public function loadFromEnv()
+    {
+        $unpredictableValues = array(
+            'COMPOSER_UPDATE_FREQ' => -100,
+        );
+        $params = new ComposerWrapperParams();
+        foreach ($unpredictableValues as $name => $value) {
+            putenv($name . '=' . $value);
+        }
+
+        $params->loadReal();
+
+        self::assertEquals(-100, $params->getUpdateFreq());
+    }
+}

--- a/tests/ComposerWrapperParamsTest.php
+++ b/tests/ComposerWrapperParamsTest.php
@@ -19,16 +19,169 @@ class ComposerWrapperParamsTest extends TestCase
      */
     public function loadFromEnv()
     {
-        $unpredictableValues = array(
+        $envValues = array(
             'COMPOSER_UPDATE_FREQ' => -100,
+            'COMPOSER_FORCE_MAJOR_VERSION' => "1",
+            'COMPOSER_DIR' => __DIR__
         );
         $params = new ComposerWrapperParams();
-        foreach ($unpredictableValues as $name => $value) {
+        self::isolatedEnv($envValues, function () use ($params) {
+            $params->loadReal();
+        });
+
+        self::assertSame('-100', $params->getUpdateFreq());
+        self::assertSame(1, $params->getForceMajorVersion());
+        self::assertSame(__DIR__, $params->getComposerDir());
+    }
+
+    protected static function isolatedEnv($env, callable $callback)
+    {
+        foreach ($env as $name => $value) {
             putenv($name . '=' . $value);
         }
+        try {
+            $callback();
+        } catch (Exception $e) {
 
-        $params->loadReal();
+        }
+        foreach ($env as $name => $value) {
+            putenv($name);
+        }
 
-        self::assertEquals(-100, $params->getUpdateFreq());
+        if (isset($e)) {
+            throw $e;
+        }
     }
+
+    public function updateFreqValues()
+    {
+        return array(
+            "default" => array(null, '7 days'),
+            "some value" => array("40 days", "40 days"),
+            "some strange value, but supported with php engine" => array(-100, "-100"),
+
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider updateFreqValues
+     */
+    public function updateFreqParamCorrectValue($input, $expected)
+    {
+        $params = new ComposerWrapperParams();
+        if (null !== $input) {
+            $params->setUpdateFreq($input);
+        }
+        self::assertSame($expected, $params->getUpdateFreq());
+    }
+
+    public function wrongUpdateFreqValues()
+    {
+        return array(
+            "integer is wrong value" => array(15),
+            "empty string" => array(''),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider wrongUpdateFreqValues
+     */
+    public function negativeValidationUpdateFreqParam($input)
+    {
+        $this->expectException('\Exception');
+        $this->expectExceptionMessageRegExp('/Wrong update frequency is requested: .*/');
+        $params = new ComposerWrapperParams();
+        $params->setUpdateFreq($input);
+    }
+
+    public function forceMajorVersionValues()
+    {
+        return array(
+            "false is default" => array(null, false),
+            "1 as int" => array(1, 1),
+            "1 as string" => array("1", 1),
+            "2 as int" => array(2, 2),
+            "2 as string" => array("2", 2),
+        );
+    }
+    /**
+     * @test
+     * @dataProvider forceMajorVersionValues
+     */
+    public function forceMajorVersionParamCorrectValues($input, $output)
+    {
+        $params = new ComposerWrapperParams();
+        if (null !== $input) {
+            $params->setForceMajorVersion($input);
+        }
+        self::assertSame($output, $params->getForceMajorVersion());
+    }
+
+    public function wrongForceMajorVersionValues()
+    {
+        return array(
+            "negative" => array(-1),
+            "allowed versions but float" => array(1.0),
+            "positive more than 2 " => array(3),
+            "zero " => array(0),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider wrongForceMajorVersionValues
+     */
+    public function negativeValidationForceMajorVersionParam($input)
+    {
+        $this->expectException('\Exception');
+        $this->expectExceptionMessageRegExp('/Wrong major version is requested:.*/');
+        $params = new ComposerWrapperParams();
+        $params->setForceMajorVersion($input);
+    }
+
+    public function composerDirValues()
+    {
+        return array(
+            "default path" => array(null, dirname(self::fullWrapperPath())),
+            "current dir" => array(__DIR__, __DIR__),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider composerDirValues
+     */
+    public function composerDirCorrectValues($input, $expected)
+    {
+        $params = new ComposerWrapperParams();
+        if (null !== $input) {
+            $params->setComposerDir($input);
+        }
+        self::assertSame($expected, $params->getComposerDir());
+    }
+
+    public function wrongComposerDirValues()
+    {
+        return array(
+            "access denied" => array('/var'),
+            "doesn't exists" => array(__DIR__ . '/i_dont_exist'),
+            "non dir" => array(__FILE__),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider wrongComposerDirValues
+     */
+    public function negativeValidationComposerDirParam($input)
+    {
+        $this->expectException('\Exception');
+        $this->expectExceptionMessageRegExp('/Wrong composer dir is requested:.*/');
+        $params = new ComposerWrapperParams();
+        $params->setComposerDir($input);
+    }
+
+
 }

--- a/tests/ComposerWrapperParamsTest.php
+++ b/tests/ComposerWrapperParamsTest.php
@@ -64,7 +64,6 @@ class ComposerWrapperParamsTest extends TestCase
     {
         return array(
             "some value" => array("40 days", "40 days"),
-            "float number, strange but supported by php engine" => array(1.5, "1.5"),
             "negative integer, strange but supported by php engine" => array(-100, "-100"),
         );
     }
@@ -95,6 +94,7 @@ class ComposerWrapperParamsTest extends TestCase
     {
         return array(
             "positive integer value" => array(100),
+            "negative DateTime modifier" => array("-1 day"),
             "zero" => array(0),
             "empty string" => array(''),
         );

--- a/tests/ComposerWrapperTest.php
+++ b/tests/ComposerWrapperTest.php
@@ -42,33 +42,7 @@ class ComposerWrapperTest extends TestCase
         $this->runCallsAllRequiredMethods(__DIR__);
     }
 
-    /**
-     * @test
-     * @expectedException Exception
-     * @expectedExceptionMessage is not a dir
-     */
-    public function runThrowsOnMissingDirFromEnv()
-    {
-        $nonExistingDir = __DIR__ . '/i_dont_exist';
-        $expectedError = "$nonExistingDir is not a dir";
-        $this->expectExceptionCompat('Exception', $expectedError);
 
-        putenv("COMPOSER_DIR=$nonExistingDir");
-        self::getInstance()->run();
-    }
-
-    /**
-     * @test
-     */
-    public function runThrowsOnNonDirFromEnv()
-    {
-        $nonDir = __FILE__;
-        $expectedExceptionMessage = "$nonDir is not a dir";
-        $this->expectExceptionCompat('Exception', $expectedExceptionMessage);
-
-        putenv("COMPOSER_DIR=$nonDir");
-        self::getInstance()->run();
-    }
 
     /**
      * @test

--- a/tests/ComposerWrapperTest.php
+++ b/tests/ComposerWrapperTest.php
@@ -130,7 +130,7 @@ class ComposerWrapperTest extends TestCase
             ->with(ComposerWrapper::EXPECTED_INSTALLER_CHECKSUM_URL)
             ->willReturn($downloadResult);
 
-        $this->expectExceptionCompat('Exception', ComposerWrapper::MSG_ERROR_DOWNLOADING_CHECKSUM);
+        $this->expectExceptionMessageCompat('Exception', ComposerWrapper::MSG_ERROR_DOWNLOADING_CHECKSUM);
 
         $mock->installComposer(__DIR__);
     }
@@ -148,7 +148,7 @@ class ComposerWrapperTest extends TestCase
      */
     public function throwsOnFailureToDownloadInstaller()
     {
-        $this->expectExceptionCompat(
+        $this->expectExceptionMessageCompat(
             'Exception',
             ComposerWrapper::MSG_ERROR_DOWNLOADING_INSTALLER
         );
@@ -175,7 +175,7 @@ class ComposerWrapperTest extends TestCase
      */
     public function throwsOnInstallerChecksumMismatch()
     {
-        $this->expectExceptionCompat(
+        $this->expectExceptionMessageCompat(
             'Exception',
             ComposerWrapper::MSG_ERROR_INSTALLER_CHECKSUM_MISMATCH
         );
@@ -251,7 +251,7 @@ class ComposerWrapperTest extends TestCase
     public function throwsOnInstallerFailure()
     {
         $this->expectOutputWithShebang('Installer was called and will return an error');
-        $this->expectExceptionCompat('Exception', ComposerWrapper::MSG_ERROR_WHEN_INSTALLING);
+        $this->expectExceptionMessageCompat('Exception', ComposerWrapper::MSG_ERROR_WHEN_INSTALLING);
 
         $mock = $this->getMockBuilder(self::WRAPPER_CLASS)
             ->setMethods(array('file_get_contents', 'copy', 'unlink'))
@@ -474,7 +474,7 @@ class ComposerWrapperTest extends TestCase
         $content = sprintf('<?php throw new Exception("%s");', $expectedExceptionText);
         $composer->setContent($content);
 
-        $this->expectExceptionCompat('Exception', $expectedExceptionText);
+        $this->expectExceptionMessageCompat('Exception', $expectedExceptionText);
         putenv("COMPOSER_DIR=$composerDir");
         $this->runCallsAllRequiredMethods($composerDir, false);
     }
@@ -569,18 +569,7 @@ class ComposerWrapperTest extends TestCase
         );
     }
 
-    private function expectExceptionCompat($class, $message)
-    {
-        if (
-            method_exists($this, 'expectExceptionMessage') &&
-            method_exists($this, 'expectException')
-        ) {
-            $this->expectException($class);
-            $this->expectExceptionMessage($message);
-        } elseif (method_exists($this, 'setExpectedException')) {
-            $this->setExpectedException($class, $message);
-        }
-    }
+
 
 
 }


### PR DESCRIPTION
Hi. I've provide some enhancement. I think, it will be good option to provide wrapper configuration not only via ENV variables.
In this PR I implemented config reading from `composer.json` file `config->wrapper->` path.

This kind of config will be useful, when developer likes set config by project but not by environment

The main code + tests part are implemented. Currently I'm doing e2e testing. The following issues are found: 
- [x] Wrapper doesn't respect `major-version` on fresh installation. #15 
- [x] major-version `0` isn't rising error when passed with json config
- [x] need update wrapper version
- [x] test, that ENV variables have the highest priority
- [x] move update-freq validation (negative value) to ComposerWrapperParams class